### PR TITLE
Several small adjustments and typos

### DIFF
--- a/source/docs/3/calculating_intersection_density.rst
+++ b/source/docs/3/calculating_intersection_density.rst
@@ -64,7 +64,7 @@ Clip the Road Network to the City Boundary
   .. image:: /static/3/calculating_intersection_density/images/data7.png
      :align: center
 
-2. Instead of opening a large layer in QGIS, we can directly read it from the disk and clip it. Open the Processing Toolbox and locate the :menuselection:`Vector overlay --> Clip`. Double-click to open it.
+2. Instead of opening a large layer in QGIS, we can directly read it from the disk and clip it. Open the Processing Toolbox and locate the :menuselection:`Vector overlay --> Clip` algorithm. Double-click to open it.
 
   .. image:: /static/3/calculating_intersection_density/images/data8.png
      :align: center
@@ -79,7 +79,7 @@ Clip the Road Network to the City Boundary
   .. image:: /static/3/calculating_intersection_density/images/data10.png
      :align: center
 
-5. Once the processing finishes, a new layer ``chennai_road`` will be loaded in the canvas. 
+5. Once the processing finishes, a new layer ``chennai_roads`` will be loaded in the canvas. 
 
   .. image:: /static/3/calculating_intersection_density/images/data11.png
      :align: center
@@ -96,7 +96,7 @@ Data source: [OPENCITIES]_ [GEOFABRIK]_
 Procedure
 ---------
 
-1. Now both layers used for the calculation will be available, if you have downloaded the data, then locate the ``Chennai-Wards-2011.kml`` and ``chennai_roads.gpkg`` in :guilabel:`Browser`, then drag and drop them on canvas. 
+1. Now both layers used for the calculation will be available, if you have downloaded the data, then locate the ``Chennai-Wards-2011.kml`` and ``chennai_roads.gpkg`` in :guilabel:`Browser`, then drag and drop them on the canvas. 
 
   .. image:: /static/3/calculating_intersection_density/images/image1.png
      :align: center
@@ -106,7 +106,7 @@ Procedure
   .. image:: /static/3/calculating_intersection_density/images/image2.png
      :align: center
 
-3. Open the Processing Toolbox and locate the :menuselection:`Vector overlay --> Line intersections tool`. Double-click to open it.
+3. Open the Processing Toolbox and locate the :menuselection:`Vector overlay --> Line intersections` algorithm. Double-click to open it.
 
   .. image:: /static/3/calculating_intersection_density/images/image3.png
      :align: center
@@ -122,7 +122,7 @@ Procedure
   .. image:: /static/3/calculating_intersection_density/images/image5.png
      :align: center
 
-6. Remove the Intersections layer and click :guilabel:`Deselect features from all layers` button to remove the selection. We will now merge all adjacent road segments, so the segments between intersections are merged into a single feature. Open the Processing Toolbox and locate the :menuselection:`Vector geometry --> Dissolve` tool. Double-click to open it.
+6. Remove the Intersections layer and click :guilabel:`Deselect features from all layers` button to remove the selection. We will now merge all adjacent road segments, so the segments between intersections are merged into a single feature. Open the Processing Toolbox and locate the :menuselection:`Vector geometry --> Dissolve` algorithm. Double-click to open it.
 
   .. image:: /static/3/calculating_intersection_density/images/image6.png
      :align: center
@@ -138,13 +138,13 @@ Procedure
   .. image:: /static/3/calculating_intersection_density/images/image8.png
      :align: center
 
-9. Next, open the Processing Toolbox and locate :menuselection:`Vector geometry --> Multipart to single parts` tool. Double-click to open it. Select ``roads_dissolved`` layer as the :guilabel:`Input layer`. Enter ``roads_singleparts.gpkg`` as the Single parts output. Click :guilabel:`Run`.
+9. Next, open the Processing Toolbox and locate :menuselection:`Vector geometry --> Multipart to single parts` algorithm. Double-click to open it. Select ``roads_dissolved`` layer as the :guilabel:`Input layer`. Enter ``roads_singleparts.gpkg`` as the Single parts output. Click :guilabel:`Run`.
 
   .. image:: /static/3/calculating_intersection_density/images/image9.png
      :align: center
 
 
-10. The resulting layer ``roads_singleparts`` will have all adjacent segments merged, remove the ``roads_dissolved`` and ``chennai_roads`` layers. Now, open the Processing Toolbox and locate :menuselection:`Vector overlay --> Line intersections` algorithm. Double-click to launch it.
+10. The resulting layer ``roads_singleparts`` will have all adjacent segments merged, remove the ``roads_dissolved`` and ``chennai_roads`` layers. Now, open the Processing Toolbox and locate the :menuselection:`Vector overlay --> Line intersections` algorithm. Double-click to launch it.
 
   .. image:: /static/3/calculating_intersection_density/images/image10.png
      :align: center
@@ -159,18 +159,18 @@ Procedure
 
    This is a computationally intensive operation and may take a long time depending on your computer processing capacity. 
 
-12. The resulting layer ``roads_line_intersections`` now have all intersections correctly identified. But it is still not perfect. Use the :guilabel:`Select features by Area tool` and select any intersection. You will see that at each intersection there are few duplicate points from adjacent segments. If we use this layer for further analysis, it will result in an inflated number of intersections. Let’s remove duplicates, open the Processing Toolbox and locate the :menuselection:`Vector general --> Delete duplicate geometries` tool. Select ``roads_line_intersections`` as the :guilabel:`Input layer` and enter ``road_intersections.gpkg`` as the :guilabel:`Cleaned` output layer. Click :guilabel:`Run`. 
+12. The resulting layer ``roads_line_intersections`` now has all intersections correctly identified. But it is still not perfect. Use the :guilabel:`Select features by Area tool` and select any intersection. You will see that at each intersection there are few duplicate points from adjacent segments. If we use this layer for further analysis, it will result in an inflated number of intersections. Let’s remove duplicates, open the Processing Toolbox and locate the :menuselection:`Vector general --> Delete duplicate geometries` algorithm. Select ``roads_line_intersections`` as the :guilabel:`Input layer` and enter ``road_intersections.gpkg`` as the :guilabel:`Cleaned` output layer. Click :guilabel:`Run`. 
 
   .. image:: /static/3/calculating_intersection_density/images/image12.png
      :align: center
 
-13. The new layer ``road_intersections`` layer has the correct number of road intersections extracted from the source layer. Right-click the old ``road_line_intersections`` layer and select :guilabel:`Remove layer` to remove it.
+13. The new ``road_intersections`` layer has the correct number of road intersections extracted from the source layer. Right-click the old ``road_line_intersections`` layer and select :guilabel:`Remove layer` to remove it.
 
   .. image:: /static/3/calculating_intersection_density/images/image13.png
      :align: center
 
 
-14. We will now compute the density of points by overlaying a regular grid and counting points in each grid polygon. We must reproject the data to a projected CRS so we can use linear units of measurements. We can use an appropriate CRS based on the UTM zone where the city is located. You can see `UTM Grid Zones of the World <http://www.dmap.co.uk/utmworld.htm>`_ map to locate the UTM zone for your city. Chennai falls in the UTM Zone **44N**. Open the Processing Toolbox and locate the :menuselection:`Vector general --> Reproject` layer. Double click to open it. 
+14. We will now compute the density of points by overlaying a regular grid and counting points in each grid polygon. We must reproject the data to a projected CRS so we can use linear units of measurements. We can use an appropriate CRS based on the UTM zone where the city is located. You can see `UTM Grid Zones of the World <http://www.dmap.co.uk/utmworld.htm>`_ map to locate the UTM zone for your city. Chennai falls in the UTM Zone **44N**. Open the Processing Toolbox and locate the :menuselection:`Vector general --> Reproject` algorithm. Double click to open it. 
 
   .. image:: /static/3/calculating_intersection_density/images/image14.png
      :align: center
@@ -186,7 +186,7 @@ Procedure
      :align: center
 
 
-17. Now we can create the grid. Open the Processing Toolbox and locate the :menuselection:`Vector creation --> Create grid`. Double click to open. 
+17. Now we can create the grid. Open the Processing Toolbox and locate the :menuselection:`Vector creation --> Create grid` algorithm. Double click to open. 
 
   .. image:: /static/3/calculating_intersection_density/images/image17.png
      :align: center
@@ -202,12 +202,12 @@ Procedure
      :align: center
 
 
-20. The ``grid`` layer containing rectangular grid polygons will be created. We can now count the number of points in each polygon, but since our layers are large, this process can take a long time. One way to speed up spatial operations is to use a *Spatial Index*. Open the Processing Toolbox and locate the :menuselection:`Vector general --> Create spatial index` tool. Double click to open it. 
+20. The ``grid`` layer containing rectangular grid polygons will be created. We can now count the number of points in each polygon, but since our layers are large, this process can take a long time. One way to speed up spatial operations is to use a *Spatial Index*. Open the Processing Toolbox and locate the :menuselection:`Vector general --> Create spatial index` algorithm. Double click to open it. 
 
   .. image:: /static/3/calculating_intersection_density/images/image20.png
      :align: center
 
-21. Select ``grid`` layer and click :guilabel:`Run`, now the layer will have spatial index which can boost the performance of computation with this layer.
+21. Select ``grid`` layer and click :guilabel:`Run`, now the layer will have a spatial index which can boost the performance of computation with this layer.
 
   .. image:: /static/3/calculating_intersection_density/images/image21.png
      :align: center
@@ -232,18 +232,18 @@ Procedure
   .. image:: /static/3/calculating_intersection_density/images/image25.png
      :align: center
 
-26. The resulting layer ``grid_counts_chennai`` will have grid polygons over the chennai city and contains the number of road intersections as an attribute for each polygon. Remove all layers except ``grid_counts_chennai``.   
+26. The resulting layer ``grid_counts_chennai`` will have grid polygons over the Chennai city and contains the number of road intersections as an attribute for each polygon. Remove all layers except ``grid_counts_chennai``.   
 
   .. image:: /static/3/calculating_intersection_density/images/image26.png
      :align: center
 
 
-27. Let’s clean up the attribute table of our data layer. The preferred method to make any changes to the attribute table is to use a processing algorithm called Refactor Fields, open the Processing Toolbox and locate the :menuselection:`Vector table --> Refactor Fields`. Double-click to open it. Click on any row in the :guilabel:`Field Mapping` section to select it. You can hold the :kbd:`Shift` key to select multiple rows, select all fields except :guilabel:`fid` and :guilabel:`NUMPOINTS`. Click the :guilabel:`Delete selected fields` button. 
+27. Let’s clean up the attribute table of our data layer. The preferred method to make any changes to the attribute table is to use a processing algorithm called Refactor Fields, open the Processing Toolbox and locate the :menuselection:`Vector table --> Refactor Fields` algorithm. Double-click to open it. Click on any row in the :guilabel:`Field Mapping` section to select it. You can hold the :kbd:`Shift` key to select multiple rows, select all fields except :guilabel:`fid` and :guilabel:`NUMPOINTS`. Click the :guilabel:`Delete selected fields` button. 
 
   .. image:: /static/3/calculating_intersection_density/images/image27.png
      :align: center
 
-28. Rename the :guilabel:`NUMPOINTS` as ``intersection_density`` and save the layer as ``road_intersection_density.gpkg``, click :guilabel:`Run`. 
+28. Rename the :guilabel:`NUMPOINTS` field as ``intersection_density`` and save the layer as ``road_intersection_density.gpkg``, click :guilabel:`Run`. 
 
   .. image:: /static/3/calculating_intersection_density/images/image28.png
      :align: center
@@ -254,7 +254,7 @@ Procedure
      :align: center
 
 
-30. In the values enter ``0-50``, ``50-100``, ``100-150`` and so on upto ``300 - 350``. You have now created a map showing intersection density across the city.
+30. In the values enter ``0-50``, ``50-100``, ``100-150`` and so on up to ``300 - 350``. You have now created a map showing intersection density across the city.
 
   .. image:: /static/3/calculating_intersection_density/images/image30.png
      :align: center


### PR DESCRIPTION
line 67 : "locate the :menuselection:`Vector overlay --> Clip`."  - added "algorithm"
			"locate the :menuselection:`Vector overlay --> Clip` algorithm." - for consistency
				
line 82 : ``chennai_road``  should be  ``chennai_roads``  for consistency
			
line 99 : "them on canvas."  should be "them on the canvas."  - added "the"

line 109 : "locate the :menuselection:`Vector overlay --> Line intersections tool`."  should be			
			"locate the :menuselection:`Vector overlay --> Line intersections` algorithm." - for consistency
		
line 125 : "locate the :menuselection:`Vector geometry --> Dissolve` tool." should be
			"locate the :menuselection:`Vector geometry --> Dissolve` algorithm." - for consistency
	 
line 141 : "locate :menuselection:`Vector geometry --> Multipart to single parts` tool." should be
			"locate the :menuselection:`Vector geometry --> Multipart to single parts` algorithm." - for consistency
	
line 147 : "locate :menuselection:`Vector overlay"  should be "locate the :menuselection:`Vector overlay" - added "the"  
	
line 162 : "The resulting layer ``roads_line_intersections`` now have all intersections correctly identified." should probably be singular
			"The resulting layer ``roads_line_intersections`` now has all intersections correctly identified."
	
line 162 : "Delete duplicate geometries` tool."  "tool" should be "algorithm" - for consistency
	
line 167 : "new layer ``road_intersections`` layer" - double wording "layer"  - removed first item
	
line 173 : "--> Reproject` layer."   "layer" should be "algorithm" - for consistency (probably a typo here)
	
line 189 : "locate the :menuselection:`Vector creation --> Create grid`." should be
			"locate the :menuselection:`Vector creation --> Create grid` algorithm." - for consistency
	
line 205 : "locate the :menuselection:`Vector general --> Create spatial index` tool." should be
			"locate the :menuselection:`Vector general --> Create spatial index` algorithm." - for consistency
	
line 210 : "will have spatial index" should probably be "will have a spatial index" - added "a"

line 235 : "the chennai city" should probably be "the Chennai city" - capital "C" for name of city

line 241 : "locate the :menuselection:`Vector table --> Refactor Fields`." should be
			"locate the :menuselection:`Vector table --> Refactor Fields` algorithm." - for consistency

line 246 : "the :guilabel:`NUMPOINTS` as"  should probably be "the :guilabel:`NUMPOINTS` field as" - added "field" 

line 257 : "upto ``300 - 350``. " should probably be "up to ``300 - 350``." split "upto" to "up to"