### PR TITLE
Link to download does not work

### DIFF
--- a/source/docs/3/importing_spreadsheets_csv.rst
+++ b/source/docs/3/importing_spreadsheets_csv.rst
@@ -22,7 +22,7 @@ Get the data
 
 For convenience, you may directly download a copy of the above datasets from the link below:
 
-`earthquakes_2021_11_25_14_31_59_+0530.tsv <https://www.qgistutorials.com/downloads/earthquakes-2021-11-25_14-31-59_+0530.tsv>`_ 
+`earthquakes_2021_11_25_14_31_59_+0530.tsv <https://www.qgistutorials.com/downloads/earthquakes-2021-11-25_14-31-59_+0530.tsv>`_
 
 Data Source [NCEI]_
 


### PR DESCRIPTION
Line 25 :  the link to download the tsv-file -> https://www.qgistutorials.com/downloads/earthquakes-2021-11-25_14-31-59_+0530.tsv
does not work !
It takes you back to the homepage