### PR TITLE
Update building_a_python_plugin.rst

### DIFF
--- a/source/docs/3/building_a_python_plugin.rst
+++ b/source/docs/3/building_a_python_plugin.rst
@@ -38,7 +38,7 @@ you are using. For building plugins we need the ``pyrcc5`` command-line tool.
 
 **Windows**
 
-Relevant pyhon bindings are included in the QGIS install on Windows. But to use them from the plugin folder, we need to indicate the path to the QGIS install. 
+Relevant python bindings are included in the QGIS install on Windows. But to use them from the plugin folder, we need to indicate the path to the QGIS install. 
 
 Create a Windows Batch file (.bat extension) with the following content and save it on your computer as ``compile.bat``. We will later copy this file to the plugin folder. If you installed QGIS at a different path, replace the ``C:\OSGeo4W64\bin\`` with your path.
 


### PR DESCRIPTION
Corrected a typo error. Changed 'pyhon' to 'python' in __building a python plugin__ documentation