### PR TITLE
Some typo's corrected (cartogram_animation.rst)

### DIFF
--- a/source/docs/3/cartogram_animation.rst
+++ b/source/docs/3/cartogram_animation.rst
@@ -108,7 +108,7 @@ Procedure
   .. image:: /static/3/cartogram_animation/images/2.png
     :align: center
 
-3. Search and locate the :menuselection:`Vector table --> Field calculator` algorithm from the Processing Toolbox. double-click to open it.
+3. Search and locate the :menuselection:`Vector table --> Field calculator` algorithm from the Processing Toolbox. Double-click to open it.
 
   .. image:: /static/3/cartogram_animation/images/3.png
     :align: center
@@ -133,7 +133,7 @@ Procedure
   .. image:: /static/3/cartogram_animation/images/6.png
     :align: center
     
-7. In Area cartograms, the scale factor determines how much the feature's area is reduced. We must reduce each feature's area so that the population density of the feature is the same as the population density of the anchor feature. The formula for scale factor is the ratio of the square-root of the feature's value against the square-root of the value of the anchor feature. Open the :menuselection:`Vector table --> Field calculator` algorithm from the Processing Toolbox. In the :guilabel:`Field calculator` dialog, select ``us_states_population_density`` as the :guilabel:`Input layer`. Enter ``scale_factor`` as the :guilabel:`Field name`. Enter the following expression to compute the scale factor. The expression calculates the ratio of the square root of the feature's density against the square root of the density of the second largest density value.  Click the :guilabel:`...` button next to :guilabel:`Calculated` and select :guilabel:`Save to File...`. Enter the name of the layer as ``us_states_scale_factor.gpkg`` and select :guilabel:`Save`. Click :guilabel:`Run`.
+7. In Area cartograms, the scale factor determines how much the feature's area is reduced. We must reduce each feature's area so that the population density of the feature is the same as the population density of the anchor feature. The formula for scale factor is the ratio of the square-root of the feature's value against the square-root of the value of the anchor feature. Open the :menuselection:`Vector table --> Field calculator` algorithm from the Processing Toolbox. In the :guilabel:`Field calculator` dialog, select ``us_states_population_density`` as the :guilabel:`Input layer`. Enter ``scale_factor`` as the :guilabel:`Field name`. Enter the following expression to compute the scale factor. The expression calculates the ratio of the square root of the feature's density against the square root of the density of the second largest density value. Click the :guilabel:`...` button next to :guilabel:`Calculated` and select :guilabel:`Save to File...`. Enter the name of the layer as ``us_states_scale_factor.gpkg`` and select :guilabel:`Save`. Click :guilabel:`Run`.
 
   .. code-block:: none
   
@@ -154,7 +154,7 @@ Procedure
  .. image:: /static/3/cartogram_animation/images/9.png
    :align: center
  
-10. Select the ``us_states_scale_factor`` layer and click the :guilabel:`Open the layer styling panel` button in the :guilabel:`Layers` panel. Select :guilabel:`Simple Fill` and open the drop-down selector for :guilabel:`Symbol layer type`. Set the :guilabel:`Symbol layer type` to ``Outline: Simple Line`` and select a :guilabel:`Color` of your choice. This symbol layer will be a a reference for our map when we resize the polygons. 
+10. Select the ``us_states_scale_factor`` layer and click the :guilabel:`Open the layer styling panel` button in the :guilabel:`Layers` panel. Select :guilabel:`Simple Fill` and open the drop-down selector for :guilabel:`Symbol layer type`. Set the :guilabel:`Symbol layer type` to ``Outline: Simple Line`` and select a :guilabel:`Color` of your choice. This symbol layer will be a reference for our map when we resize the polygons. 
 
   .. image:: /static/3/cartogram_animation/images/10.png
     :align: center
@@ -240,7 +240,7 @@ Procedure
   .. image:: /static/3/cartogram_animation/images/20.png
     :align: center
 
-21 .The default :guilabel:`Animation range` will be populated with a 24-hour window in the increment of 1-hour. This is fine for our use case as we will get 24-frames of animation. You can adjust this if you want a slower/faster animation. Right-click the ``us_states_with_population`` layer and select :guilabel:`Properties`.
+21. The default :guilabel:`Animation range` will be populated with a 24-hour window in the increment of 1-hour. This is fine for our use case as we will get 24-frames of animation. You can adjust this if you want a slower/faster animation. Right-click the ``us_states_with_population`` layer and select :guilabel:`Properties`.
 
   .. image:: /static/3/cartogram_animation/images/21.png
     :align: center
@@ -282,7 +282,7 @@ Procedure
   .. image:: /static/3/cartogram_animation/images/24.png
     :align: center
     
-25 . Back in the :guilabel:`Temporal Controller` panel, click the :guilabel:`Play` button to see the animation. You should see the shape of each polygon gradually scaled after each frame. 
+25. Back in the :guilabel:`Temporal Controller` panel, click the :guilabel:`Play` button to see the animation. You should see the shape of each polygon gradually scaled after each frame. 
 
   .. image:: /static/3/cartogram_animation/images/25.png
     :align: center


### PR DESCRIPTION
source/docs/3/cartogram_animation.rst:111 
Toolbox. double  ==>>  Double

source/docs/3/cartogram_animation.rst:136
value.  Click  ==>>  value. Click m (removed space)

source/docs/3/cartogram_animation.rst:157
be a a reference  ==>>  removed one "a"

source/docs/3/cartogram_animation.rst:243
21 .The default  ==>>  21. The default

source/docs/3/cartogram_animation.rst:285 
25 . Back  ==>>  25. Back