### PR TITLE
Wrong command ??

### DIFF
--- a/source/docs/3/isometric_buildings.rst
+++ b/source/docs/3/isometric_buildings.rst
@@ -152,7 +152,7 @@ Procedure
     .. image:: /static/3/isometric_buildings/images/14.png
       :align: center
 	
-15. Click on the :guilabel:`Data define override` for the bottom color selector and check :guilabel:`Transparent` box. 
+15. Click on the small black triangle of the bottom color selector and check :guilabel:`Transparent` box. 
 
     .. image:: /static/3/isometric_buildings/images/15.png
       :align: center


### PR DESCRIPTION
This didn't work on my system (Win11):
line 155 :
Click on the :guilabel:`Data define override` for the bottom color selector and check :guilabel:`Transparent` box. (No such box in the menu of `Data define override` 
 ___________________________________

Had to use instead:

Click on the small black triangle of the bottom color selector and check :guilabel:`Transparent` box.

+++++++++++++++++
Please check right manner to accomplish